### PR TITLE
adding a cc-by-sa-nc license

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -63,6 +63,9 @@
   _blank" rel="noopener noreferrer">
     {{ partial "logo" }}
   </a>
+
+<a aria-label="Creative Commons CC-BY-SA Licensed" rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" /></a>
+
 </div>
 
 <script>


### PR DESCRIPTION
This commit adds a CC license underneath the Internews logo on the left nav on the desktop version. 

This PR adds the http://creativecommons.org/licenses/by-nc-sa/4.0/ (attribution, adaptation with same license, non-commercial), but the CC chooser (https://creativecommons.org/choose/) can advise on alternatives. Non-commercial specifically can be difficult. It protects the work from people reprinting it as-is for profit, but it could also limit the use of the curricula in paid trainings in commercial settings.